### PR TITLE
Webhook support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
 
 install:
   - go get github.com/pkg/errors
+  - go get github.com/stretchr/testify/require
 
 script:
   - cd $TRAVIS_BUILD_DIR && go test ./...

--- a/webhook.go
+++ b/webhook.go
@@ -20,6 +20,12 @@ type Callback interface {
 	isCallback()
 }
 
+func (PaymentCallback) isCallback()       {}
+func (AuthorizationCallback) isCallback() {}
+func (CaptureCallback) isCallback()       {}
+func (VoidCallback) isCallback()          {}
+func (RefundCallback) isCallback()        {}
+
 type CallbackCommon struct {
 	EventType      string `json:"-"` // The type of resource that triggered the event. For example, "payment.authorization.create". Returned in "event-type" header.
 	XPaymentsOSEnv string `json:"-"` // PaymentsOS environment, 'live' or 'test'. Returned in "x-payments-os-env" header.
@@ -31,8 +37,6 @@ type CallbackCommon struct {
 	AppID     string    `json:"app_id"`
 	PaymentID string    `json:"payment_id"`
 }
-
-func (CallbackCommon) isCallback() {}
 
 type PaymentCallback struct {
 	CallbackCommon

--- a/webhook.go
+++ b/webhook.go
@@ -72,6 +72,12 @@ func (f PrivateKeyProviderFunc) PrivateKey(ctx context.Context, appID string) ([
 	return f(ctx, appID)
 }
 
+type FixedPrivateKeyProvider map[string][]byte
+
+func (m FixedPrivateKeyProvider) PrivateKey(_ context.Context, appID string) ([]byte, error) {
+	return m[appID], nil
+}
+
 type ErrBadRequest struct {
 	Err error
 }

--- a/webhook.go
+++ b/webhook.go
@@ -1,0 +1,224 @@
+package zooz
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const headerEventType = "event-type"
+
+type Callback interface {
+	isCallback()
+}
+
+type CallbackCommon struct {
+	EventType      string `json:"-"` // The type of resource that triggered the event. For example, "payment.authorization.create". Returned in "event-type" header.
+	XPaymentsOSEnv string `json:"-"` // PaymentsOS environment, 'live' or 'test'. Returned in "x-payments-os-env" header.
+	XZoozRequestID string `json:"-"` // The ID of the original request that triggered the webhook event. Returned in "x-zooz-request-id" header.
+
+	ID        string    `json:"id"`      // The Webhook id. This id is unique per Webhook and can be used to validate that the request is unique.
+	Created   time.Time `json:"created"` // The date and time the event was created. "2018-10-03T04:58:35.385Z".
+	AccountID string    `json:"account_id"`
+	AppID     string    `json:"app_id"`
+	PaymentID string    `json:"payment_id"`
+}
+
+func (CallbackCommon) isCallback() {}
+
+type PaymentCallback struct {
+	CallbackCommon
+	Data Payment `json:"data"`
+}
+
+type AuthorizationCallback struct {
+	CallbackCommon
+	Data Authorization `json:"data"`
+}
+
+type CaptureCallback struct {
+	CallbackCommon
+	Data Capture `json:"data"`
+}
+
+type VoidCallback struct {
+	CallbackCommon
+	Data Void `json:"data"`
+}
+
+type RefundCallback struct {
+	CallbackCommon
+	Data Refund `json:"data"`
+}
+
+type privateKeyProvider interface {
+	// PrivateKey should return private key for given business unit. It is used to validate request signature.
+	// For unknown business units (including empty appID) it should return (nil, nil).
+	PrivateKey(ctx context.Context, appID string) ([]byte, error)
+}
+
+type PrivateKeyProviderFunc func(ctx context.Context, appID string) ([]byte, error)
+
+func (f PrivateKeyProviderFunc) PrivateKey(ctx context.Context, appID string) ([]byte, error) {
+	return f(ctx, appID)
+}
+
+type ErrBadRequest struct {
+	Err error
+}
+
+func (e ErrBadRequest) Error() string { return e.Err.Error() }
+
+func (e ErrBadRequest) Unwrap() error { return e.Err }
+
+// DecodeWebhookRequest decodes PaymentsOS webhook http request into callback entity.
+// Supports webhook version >= 1.2.0
+//
+// Will return ErrBadRequest if the error is permanent and request should not be retried.
+// Bear in mind that your webhook handler should respond with 2xx status code anyway, otherwise PaymentsOS will continue
+// resending this request.
+// ErrBadRequest errors include:
+// 	* wrong body format (broken/invalid json, ...)
+//  * validation error (missing required fields or headers, unexpected values)
+// 	* unknown business unit (app_id)
+//  * incorrect request signature
+func DecodeWebhookRequest(ctx context.Context, r *http.Request, keyProvider privateKeyProvider) (Callback, error) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "read request body")
+	}
+
+	// Validate request signature
+	signature, err := CalculateWebhookSignature(ctx, body, r.Header, keyProvider)
+	if err != nil {
+		return nil, errors.WithMessage(err, "calculate request signature")
+	}
+	if "sig1="+signature != r.Header.Get("signature") {
+		return nil, ErrBadRequest{errors.New("incorrect signature")}
+	}
+
+	// Decode request into appropriate entity type based on "event-type" header
+	eventType := r.Header.Get(headerEventType)
+	common := CallbackCommon{
+		EventType:      eventType,
+		XPaymentsOSEnv: r.Header.Get("x-payments-os-env"),
+		XZoozRequestID: r.Header.Get("x-zooz-request-id"),
+	}
+	var cbRef Callback
+	switch true {
+	case strings.HasPrefix(eventType, "payment.payment."):
+		cbRef = &PaymentCallback{CallbackCommon: common}
+	case strings.HasPrefix(eventType, "payment.authorization."):
+		cbRef = &AuthorizationCallback{CallbackCommon: common}
+	case strings.HasPrefix(eventType, "payment.capture."):
+		cbRef = &CaptureCallback{CallbackCommon: common}
+	case strings.HasPrefix(eventType, "payment.void."):
+		cbRef = &VoidCallback{CallbackCommon: common}
+	case strings.HasPrefix(eventType, "payment.refund."):
+		cbRef = &RefundCallback{CallbackCommon: common}
+	default:
+		return nil, ErrBadRequest{errors.Errorf("unsupported event type: %q", eventType)}
+	}
+
+	if err := json.Unmarshal(body, cbRef); err != nil {
+		return nil, errors.Wrapf(err, "unmarshal request body into entity of type %T", cbRef)
+	}
+	return deref(cbRef), nil
+}
+
+// Calculate webhook request signature (without "sig1=" prefix).
+// reqBody should be a raw webhook http request body.
+// reqHeader should be webhook http request headers (currently only 'event-type' header matters).
+// Will return ErrBadRequest{} if error is permanent and should not be retried (malformed json body, unknown app_id)
+// Also used by DecodeWebhookRequest.
+func CalculateWebhookSignature(ctx context.Context, reqBody []byte, reqHeader http.Header, keyProvider privateKeyProvider) (string, error) {
+	type signatureFields struct {
+		ID        string `json:"id"`
+		Created   string `json:"created"`
+		AccountID string `json:"account_id"`
+		AppID     string `json:"app_id"`
+		PaymentID string `json:"payment_id"`
+		Data      struct {
+			ID     string `json:"id"`
+			Result struct {
+				Status      string `json:"status"`
+				Category    string `json:"category"`
+				SubCategory string `json:"sub_category"`
+			} `json:"result"`
+			ProviderData struct {
+				ResponseCode string `json:"response_code"`
+			} `json:"provider_data"`
+			ReconciliationID string `json:"reconciliation_id"`
+			Amount           *int64 `json:"amount"`
+			Currency         string `json:"currency"`
+		} `json:"data"`
+	}
+
+	f := signatureFields{}
+	if err := json.Unmarshal(reqBody, &f); err != nil {
+		return "", ErrBadRequest{errors.Wrapf(err, "unmarshal request body into entity of type %T", f)}
+	}
+
+	key, err := keyProvider.PrivateKey(ctx, f.AppID)
+	if err != nil {
+		return "", errors.Wrap(err, "select private key by app_id")
+	}
+	if key == nil {
+		return "", ErrBadRequest{errors.Errorf("unknown app_id %q", f.AppID)}
+	}
+
+	var amount string
+	if f.Data.Amount != nil {
+		amount = strconv.FormatInt(*f.Data.Amount, 10)
+	} else {
+		amount = ""
+	}
+	values := []string{
+		reqHeader.Get(headerEventType),
+		f.ID,
+		f.AccountID,
+		f.PaymentID,
+		f.Created,
+		f.AppID,
+		f.Data.ID,
+		f.Data.Result.Status,
+		f.Data.Result.Category,
+		f.Data.Result.SubCategory,
+		f.Data.ProviderData.ResponseCode,
+		f.Data.ReconciliationID,
+		amount,
+		f.Data.Currency,
+	}
+	mac := hmac.New(sha256.New, key)
+	if _, err := mac.Write([]byte(strings.Join(values, ","))); err != nil {
+		return "", errors.Wrap(err, "sha256 calculation") // should never happen since sha256.digest::Write() never returns error
+	}
+	sha := hex.EncodeToString(mac.Sum(nil))
+	return sha, nil
+}
+
+func deref(cb Callback) Callback {
+	switch cb := cb.(type) {
+	case *PaymentCallback:
+		return *cb
+	case *AuthorizationCallback:
+		return *cb
+	case *CaptureCallback:
+		return *cb
+	case *VoidCallback:
+		return *cb
+	case *RefundCallback:
+		return *cb
+	default:
+		panic("should be a pointer to a known callback type")
+	}
+}

--- a/webhook_example_test.go
+++ b/webhook_example_test.go
@@ -13,7 +13,8 @@ func ExampleDecodeWebhookRequest() {
 	keyProvider := zooz.FixedPrivateKeyProvider{"app-id": []byte("my-private-key")}
 
 	_ = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		cb, err := zooz.DecodeWebhookRequest(r.Context(), r, keyProvider)
+		body, _ := ioutil.ReadAll(r.Body)
+		cb, err := zooz.DecodeWebhookRequest(r.Context(), body, r.Header, keyProvider)
 		if err != nil {
 			if errors.As(err, &zooz.ErrBadRequest{}) {
 				// Invalid request. We don't want PaymentsOS to resend it, so respond with 2xx code.

--- a/webhook_example_test.go
+++ b/webhook_example_test.go
@@ -1,0 +1,51 @@
+package zooz_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/gtforge/go-zooz"
+	"github.com/pkg/errors"
+)
+
+func ExampleDecodeWebhookRequest() {
+	keyProvider := zooz.FixedPrivateKeyProvider{"app-id": []byte("my-private-key")}
+
+	_ = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cb, err := zooz.DecodeWebhookRequest(r.Context(), r, keyProvider)
+		if err != nil {
+			if errors.As(err, &zooz.ErrBadRequest{}) {
+				// Invalid request. We don't want PaymentsOS to resend it, so respond with 2xx code.
+				rw.WriteHeader(200)
+			} else {
+				// Temporary problem.
+				rw.WriteHeader(500)
+			}
+			return
+		}
+
+		switch cb := cb.(type) {
+		case zooz.AuthorizationCallback:
+			fmt.Printf("authorization: %+v", cb.Data)
+		case zooz.CaptureCallback:
+			fmt.Printf("capture: %+v", cb.Data)
+		}
+
+		rw.WriteHeader(200)
+	})
+}
+
+func ExampleCalculateWebhookSignature() {
+	keyProvider := zooz.FixedPrivateKeyProvider{"app-id": []byte("my-private-key")}
+
+	_ = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		body, _ := ioutil.ReadAll(r.Body)
+		signature, _ := zooz.CalculateWebhookSignature(r.Context(), body, r.Header, keyProvider)
+		if "sig1="+signature == r.Header.Get("signature") {
+			fmt.Print("Request signature is valid")
+		} else {
+			fmt.Print("Request signature is invalid")
+		}
+	})
+}

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"net/http"
-	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -58,13 +57,13 @@ func TestDecodeWebhookRequest_Payment(t *testing.T) {
 		"customer_id": "` + expected.Data.CustomerID + `"
 	}
 }`
-	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
-	r.Header.Set("event-type", expected.EventType)
-	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
-	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
-	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
+	h := http.Header{}
+	h.Set("event-type", expected.EventType)
+	h.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	h.Set("x-zooz-request-id", expected.XZoozRequestID)
+	h.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), h))
 
-	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), []byte(body), h, keyProvider)
 	require.NoError(t, err)
 	require.Equal(t, expected, cb)
 }
@@ -124,13 +123,13 @@ func TestDecodeWebhookRequest_Authorization(t *testing.T) {
   		}
 	}
 }`
-	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
-	r.Header.Set("event-type", expected.EventType)
-	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
-	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
-	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
+	h := http.Header{}
+	h.Set("event-type", expected.EventType)
+	h.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	h.Set("x-zooz-request-id", expected.XZoozRequestID)
+	h.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), h))
 
-	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), []byte(body), h, keyProvider)
 	require.NoError(t, err)
 	require.Equal(t, expected, cb)
 }
@@ -192,13 +191,13 @@ func TestDecodeWebhookRequest_Capture(t *testing.T) {
   		}
 	}
 }`
-	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
-	r.Header.Set("event-type", expected.EventType)
-	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
-	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
-	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
+	h := http.Header{}
+	h.Set("event-type", expected.EventType)
+	h.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	h.Set("x-zooz-request-id", expected.XZoozRequestID)
+	h.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), h))
 
-	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), []byte(body), h, keyProvider)
 	require.NoError(t, err)
 	require.Equal(t, expected, cb)
 }
@@ -254,13 +253,13 @@ func TestDecodeWebhookRequest_Void(t *testing.T) {
   		}
 	}
 }`
-	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
-	r.Header.Set("event-type", expected.EventType)
-	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
-	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
-	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
+	h := http.Header{}
+	h.Set("event-type", expected.EventType)
+	h.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	h.Set("x-zooz-request-id", expected.XZoozRequestID)
+	h.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), h))
 
-	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), []byte(body), h, keyProvider)
 	require.NoError(t, err)
 	require.Equal(t, expected, cb)
 }
@@ -326,13 +325,13 @@ func TestDecodeWebhookRequest_Refund(t *testing.T) {
   		}
 	}
 }`
-	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
-	r.Header.Set("event-type", expected.EventType)
-	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
-	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
-	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
+	h := http.Header{}
+	h.Set("event-type", expected.EventType)
+	h.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	h.Set("x-zooz-request-id", expected.XZoozRequestID)
+	h.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), h))
 
-	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), []byte(body), h, keyProvider)
 	require.NoError(t, err)
 	require.Equal(t, expected, cb)
 }
@@ -346,11 +345,11 @@ func TestDecodeWebhookRequest_BadRequestError_BrokenJson(t *testing.T) {
     		"account_id": "test-account-id",
     		"app_id": "test-app-id",
 `
-	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
-	r.Header.Set("event-type", "payment.void.create")
-	r.Header.Set("signature", "sig1=doesntmatter")
+	h := http.Header{}
+	h.Set("event-type", "payment.void.create")
+	h.Set("signature", "sig1=doesntmatter")
 
-	_, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	_, err := zooz.DecodeWebhookRequest(context.Background(), []byte(body), h, keyProvider)
 	require.Error(t, err)
 	require.True(t, errors.As(err, &zooz.ErrBadRequest{}))
 	require.Contains(t, err.Error(), "unmarshal request body")
@@ -377,11 +376,11 @@ func TestDecodeWebhookRequest_BadRequestError_UnsupportedEventType(t *testing.T)
   		}
 	}
 }`
-	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
-	r.Header.Set("event-type", "payment.XXXX.create")
-	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
+	h := http.Header{}
+	h.Set("event-type", "payment.XXXX.create")
+	h.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), h))
 
-	_, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	_, err := zooz.DecodeWebhookRequest(context.Background(), []byte(body), h, keyProvider)
 	require.Error(t, err)
 	require.True(t, errors.As(err, &zooz.ErrBadRequest{}))
 	require.Contains(t, err.Error(), `unsupported event type: "payment.XXXX.create"`)
@@ -408,11 +407,11 @@ func TestDecodeWebhookRequest_BadRequestError_UnknownBusinessUnit(t *testing.T) 
   		}
 	}
 }`
-	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
-	r.Header.Set("event-type", "payment.void.create")
-	r.Header.Set("signature", "sig1=doesntmatter")
+	h := http.Header{}
+	h.Set("event-type", "payment.void.create")
+	h.Set("signature", "sig1=doesntmatter")
 
-	_, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	_, err := zooz.DecodeWebhookRequest(context.Background(), []byte(body), h, keyProvider)
 	require.Error(t, err)
 	require.True(t, errors.As(err, &zooz.ErrBadRequest{}))
 	require.Contains(t, err.Error(), `unknown app_id "UNKNOWN-app-id"`)
@@ -439,11 +438,11 @@ func TestDecodeWebhookRequest_BadRequestError_IncorrectSignature(t *testing.T) {
   		}
 	}
 }`
-	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
-	r.Header.Set("event-type", "payment.void.create")
-	r.Header.Set("signature", "sig1=iaminvalid")
+	h := http.Header{}
+	h.Set("event-type", "payment.void.create")
+	h.Set("signature", "sig1=iaminvalid")
 
-	_, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	_, err := zooz.DecodeWebhookRequest(context.Background(), []byte(body), h, keyProvider)
 	require.Error(t, err)
 	require.True(t, errors.As(err, &zooz.ErrBadRequest{}))
 	require.Contains(t, err.Error(), `incorrect signature`)

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -1,0 +1,780 @@
+package zooz_test
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gtforge/go-zooz"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeWebhookRequest_Payment(t *testing.T) {
+	const eventType = "payment.payment.create"
+	const privateKey = "test-private-key"
+
+	expected := zooz.PaymentCallback{
+		CallbackCommon: zooz.CallbackCommon{
+			EventType:      eventType,
+			XPaymentsOSEnv: "live",
+			XZoozRequestID: "test-x-zooz-request-id",
+
+			ID:        "test-webhook-id",
+			Created:   time.Date(2018, 10, 03, 04, 58, 35, 385000000, time.UTC), // "2018-10-03T04:58:35.385Z"
+			AccountID: "test-account-id",
+			AppID:     "t",
+			PaymentID: "test-payment-id",
+		},
+		Data: zooz.Payment{
+			ID: "test-transaction-id",
+			PaymentParams: zooz.PaymentParams{
+				Amount:     1000,
+				Currency:   "USD",
+				CustomerID: "test-customer-id",
+			},
+			Status: zooz.PaymentStatusAuthorized,
+		},
+	}
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
+		require.Equal(t, expected.AppID, appID)
+		return []byte(privateKey), nil
+	})
+
+	body :=
+		`{
+	"id": "` + expected.ID + `",
+    "created": "2018-10-03T04:58:35.385Z",
+    "account_id": "` + expected.AccountID + `",
+    "app_id": "` + expected.AppID + `",
+    "payment_id": "` + expected.PaymentID + `",
+	"data": {
+		"id": "` + expected.Data.ID + `",
+		"status": "` + string(expected.Data.Status) + `",
+  		"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
+		"currency":"` + expected.Data.Currency + `",
+		"customer_id": "` + expected.Data.CustomerID + `"
+	}
+}`
+	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
+	r.Header.Set("event-type", eventType)
+	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
+	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
+
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t, expected, cb)
+}
+
+func TestDecodeWebhookRequest_Authorization(t *testing.T) {
+	const eventType = "payment.authorization.create"
+	const privateKey = "test-private-key"
+
+	expected := zooz.AuthorizationCallback{
+		CallbackCommon: zooz.CallbackCommon{
+			EventType:      eventType,
+			XPaymentsOSEnv: "live",
+			XZoozRequestID: "test-x-zooz-request-id",
+
+			ID:        "test-webhook-id",
+			Created:   time.Date(2018, 10, 03, 04, 58, 35, 385000000, time.UTC), // "2018-10-03T04:58:35.385Z"
+			AccountID: "test-account-id",
+			AppID:     "test-app-id",
+			PaymentID: "test-payment-id",
+		},
+		Data: zooz.Authorization{
+			ID: "test-transaction-id",
+			Result: zooz.Result{
+				Status:      "Pending",
+				Category:    "payment_method_declined",
+				SubCategory: "declined_by_issuing_bank",
+				Description: "The transaction was declined by the Issuing bank.",
+			},
+			Amount:           1000,
+			ReconciliationID: "test-reconciliation-id",
+			ProviderData: zooz.ProviderData{
+				ProviderName: "test-provider-name",
+				ResponseCode: "test-response-code",
+			},
+		},
+	}
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
+		require.Equal(t, expected.AppID, appID)
+		return []byte(privateKey), nil
+	})
+
+	body :=
+		`{
+	"id": "` + expected.ID + `",
+    "created": "2018-10-03T04:58:35.385Z",
+    "account_id": "` + expected.AccountID + `",
+    "app_id": "` + expected.AppID + `",
+    "payment_id": "` + expected.PaymentID + `",
+	"data": {
+		"id": "` + expected.Data.ID + `",
+  		"result": {
+			"status": "` + expected.Data.Result.Status + `",
+    		"category": "` + expected.Data.Result.Category + `",
+    		"sub_category": "` + expected.Data.Result.SubCategory + `",
+    		"description": "` + expected.Data.Result.Description + `"
+  		},
+  		"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
+  		"reconciliation_id": "` + expected.Data.ReconciliationID + `",
+  		"provider_data": {
+    		"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
+    		"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
+  		}
+	}
+}`
+	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
+	r.Header.Set("event-type", eventType)
+	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
+	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
+
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t, expected, cb)
+}
+
+func TestDecodeWebhookRequest_Capture(t *testing.T) {
+	const eventType = "payment.capture.update"
+	const privateKey = "test-private-key"
+
+	expected := zooz.CaptureCallback{
+		CallbackCommon: zooz.CallbackCommon{
+			EventType:      eventType,
+			XPaymentsOSEnv: "live",
+			XZoozRequestID: "test-x-zooz-request-id",
+
+			ID:        "test-webhook-id",
+			Created:   time.Date(2018, 10, 03, 05, 14, 17, 196000000, time.UTC), // "2018-10-03T05:14:17.196Z"
+			AccountID: "test-account-id",
+			AppID:     "test-app-id",
+			PaymentID: "test-payment-id",
+		},
+		Data: zooz.Capture{
+			ID: "test-transaction-id",
+			Result: zooz.Result{
+				Status:      "Pending",
+				Category:    "payment_method_declined",
+				SubCategory: "declined_by_issuing_bank",
+				Description: "The transaction was declined by the Issuing bank.",
+			},
+			CaptureParams: zooz.CaptureParams{
+				ReconciliationID: "test-reconciliation-id",
+				Amount:           2000,
+			},
+			ProviderData: zooz.ProviderData{
+				ProviderName: "test-provider-name",
+				ResponseCode: "test-response-code",
+			},
+		},
+	}
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
+		require.Equal(t, expected.AppID, appID)
+		return []byte(privateKey), nil
+	})
+
+	body :=
+		`{
+	"id": "` + expected.ID + `",
+    "created": "2018-10-03T05:14:17.196Z",
+    "account_id": "` + expected.AccountID + `",
+    "app_id": "` + expected.AppID + `",
+    "payment_id": "` + expected.PaymentID + `",
+	"data": {
+		"id": "` + expected.Data.ID + `",
+  		"result": {
+			"status": "` + expected.Data.Result.Status + `",
+    		"category": "` + expected.Data.Result.Category + `",
+    		"sub_category": "` + expected.Data.Result.SubCategory + `",
+    		"description": "` + expected.Data.Result.Description + `"
+  		},
+  		"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
+  		"reconciliation_id": "` + expected.Data.ReconciliationID + `",
+  		"provider_data": {
+    		"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
+    		"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
+  		}
+	}
+}`
+	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
+	r.Header.Set("event-type", eventType)
+	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
+	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
+
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t, expected, cb)
+}
+
+func TestDecodeWebhookRequest_Void(t *testing.T) {
+	const eventType = "payment.void.create"
+	const privateKey = "test-private-key"
+
+	expected := zooz.VoidCallback{
+		CallbackCommon: zooz.CallbackCommon{
+			EventType:      eventType,
+			XPaymentsOSEnv: "live",
+			XZoozRequestID: "test-x-zooz-request-id",
+
+			ID:        "test-webhook-id",
+			Created:   time.Date(2018, 10, 03, 05, 14, 17, 196000000, time.UTC), // "2018-10-03T05:14:17.196Z"
+			AccountID: "test-account-id",
+			AppID:     "test-app-id",
+			PaymentID: "test-payment-id",
+		},
+		Data: zooz.Void{
+			ID: "test-transaction-id",
+			Result: zooz.Result{
+				Status:      "Pending",
+				Category:    "payment_method_declined",
+				SubCategory: "declined_by_issuing_bank",
+				Description: "The transaction was declined by the Issuing bank.",
+			},
+			ProviderData: zooz.ProviderData{
+				ProviderName: "test-provider-name",
+				ResponseCode: "test-response-code",
+			},
+		},
+	}
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
+		require.Equal(t, expected.AppID, appID)
+		return []byte(privateKey), nil
+	})
+
+	body :=
+		`{
+	"id": "` + expected.ID + `",
+    "created": "2018-10-03T05:14:17.196Z",
+    "account_id": "` + expected.AccountID + `",
+    "app_id": "` + expected.AppID + `",
+    "payment_id": "` + expected.PaymentID + `",
+	"data": {
+		"id": "` + expected.Data.ID + `",
+  		"result": {
+			"status": "` + expected.Data.Result.Status + `",
+    		"category": "` + expected.Data.Result.Category + `",
+    		"sub_category": "` + expected.Data.Result.SubCategory + `",
+    		"description": "` + expected.Data.Result.Description + `"
+  		},
+  		"provider_data": {
+    		"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
+    		"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
+  		}
+	}
+}`
+	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
+	r.Header.Set("event-type", eventType)
+	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
+	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
+
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t, expected, cb)
+}
+
+func TestDecodeWebhookRequest_Refund(t *testing.T) {
+	const eventType = "payment.refund.update"
+	const appID = "test-app-id"
+	const privateKey = "test-private-key"
+
+	expected := zooz.RefundCallback{
+		CallbackCommon: zooz.CallbackCommon{
+			EventType:      eventType,
+			XPaymentsOSEnv: "live",
+			XZoozRequestID: "test-x-zooz-request-id",
+
+			ID:        "test-webhook-id",
+			Created:   time.Date(2018, 10, 03, 05, 22, 45, 610000000, time.UTC), // "2018-10-03T05:22:45.610Z"
+			AccountID: "test-account-id",
+			AppID:     appID,
+			PaymentID: "test-payment-id",
+		},
+		Data: zooz.Refund{
+			ID: "test-transaction-id",
+			Result: zooz.Result{
+				Status:      "Pending",
+				Category:    "payment_method_declined",
+				SubCategory: "declined_by_issuing_bank",
+				Description: "The transaction was declined by the Issuing bank.",
+			},
+			RefundParams: zooz.RefundParams{
+				ReconciliationID: "test-reconciliation-id",
+				Amount:           2000,
+				CaptureID:        "test-capture-id",
+				Reason:           "reason for the refund",
+			},
+			ProviderData: zooz.ProviderData{
+				ProviderName: "test-provider-name",
+				ResponseCode: "test-response-code",
+			},
+		},
+	}
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
+		require.Equal(t, "test-app-id", appID)
+		return []byte(privateKey), nil
+	})
+
+	body :=
+		`{
+	"id": "` + expected.ID + `",
+    "created": "2018-10-03T05:22:45.610Z",
+    "account_id": "` + expected.AccountID + `",
+    "app_id": "` + expected.AppID + `",
+    "payment_id": "` + expected.PaymentID + `",
+	"data": {
+		"id": "` + expected.Data.ID + `",
+  		"result": {
+			"status": "` + expected.Data.Result.Status + `",
+    		"category": "` + expected.Data.Result.Category + `",
+    		"sub_category": "` + expected.Data.Result.SubCategory + `",
+    		"description": "` + expected.Data.Result.Description + `"
+  		},
+  		"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
+  		"reconciliation_id": "` + expected.Data.ReconciliationID + `",
+		"capture_id": "` + expected.Data.CaptureID + `",
+		"reason": "` + expected.Data.Reason + `",
+  		"provider_data": {
+    		"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
+    		"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
+  		}
+	}
+}`
+	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
+	r.Header.Set("event-type", eventType)
+	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
+	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
+
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t, expected, cb)
+}
+
+func TestDecodeWebhookRequest_BadRequestError_BrokenJson(t *testing.T) {
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
+		require.Equal(t, "test-app-id", appID)
+		return []byte("test-private-key"), nil
+	})
+
+	body := `{
+			"id": "test-webhook-id",
+    		"created": "2018-10-03T05:22:45.610Z",
+    		"account_id": "test-account-id",
+    		"app_id": "test-app-id",
+`
+	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
+	r.Header.Set("event-type", "payment.void.create")
+	r.Header.Set("x-payments-os-env", "test")
+	r.Header.Set("x-zooz-request-id", "test-zooz-request-id")
+	r.Header.Set("signature", "sig1=doesntmatter")
+
+	_, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	require.Error(t, err)
+	require.True(t, errors.As(err, &zooz.ErrBadRequest{}))
+	require.Contains(t, err.Error(), "unmarshal request body")
+}
+
+func TestDecodeWebhookRequest_BadRequestError_UnsupportedEventType(t *testing.T) {
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
+		require.Equal(t, "test-app-id", appID)
+		return []byte("test-private-key"), nil
+	})
+
+	body :=
+		`{
+	"id": "test-webhook-id",
+    "created": "2018-10-03T05:14:17.196Z",
+    "account_id": "test-account-id",
+    "app_id": "test-app-id",
+    "payment_id": "test-payment-id",
+	"data": {
+		"id": "test-transaction-id",
+  		"result": {
+			"status": "Success"
+  		},
+  		"provider_data": {
+    		"provider_name": "test-provider-name",
+    		"response_code": "0"
+  		}
+	}
+}`
+	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
+	r.Header.Set("event-type", "payment.XXXX.create")
+	r.Header.Set("x-payments-os-env", "test")
+	r.Header.Set("x-zooz-request-id", "test-zooz-request-id")
+	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
+
+	_, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	require.Error(t, err)
+	require.True(t, errors.As(err, &zooz.ErrBadRequest{}))
+	require.Contains(t, err.Error(), `unsupported event type: "payment.XXXX.create"`)
+}
+
+func TestDecodeWebhookRequest_BadRequestError_UnknownBusinessUnit(t *testing.T) {
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
+		require.Equal(t, "test-app-id", appID)
+		return nil, nil // pretend we don't know this business unit
+	})
+
+	body :=
+		`{
+	"id": "test-webhook-id",
+    "created": "2018-10-03T05:14:17.196Z",
+    "account_id": "test-account-id",
+    "app_id": "test-app-id",
+    "payment_id": "test-payment-id",
+	"data": {
+		"id": "test-transaction-id",
+  		"result": {
+			"status": "Success"
+  		},
+  		"provider_data": {
+    		"provider_name": "test-provider-name",
+    		"response_code": "0"
+  		}
+	}
+}`
+	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
+	r.Header.Set("event-type", "payment.void.create")
+	r.Header.Set("x-payments-os-env", "test")
+	r.Header.Set("x-zooz-request-id", "test-zooz-request-id")
+	r.Header.Set("signature", "sig1=doesntmatter")
+
+	_, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	require.Error(t, err)
+	require.True(t, errors.As(err, &zooz.ErrBadRequest{}))
+	require.Contains(t, err.Error(), `unknown app_id "test-app-id"`)
+}
+
+func TestDecodeWebhookRequest_BadRequestError_IncorrectSignature(t *testing.T) {
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
+		require.Equal(t, "test-app-id", appID)
+		return []byte("test-private-key"), nil
+	})
+
+	body :=
+		`{
+	"id": "test-webhook-id",
+    "created": "2018-10-03T05:14:17.196Z",
+    "account_id": "test-account-id",
+    "app_id": "test-app-id",
+    "payment_id": "test-payment-id",
+	"data": {
+		"id": "test-transaction-id",
+  		"result": {
+			"status": "Success"
+  		},
+  		"provider_data": {
+    		"provider_name": "test-provider-name",
+    		"response_code": "0"
+  		}
+	}
+}`
+	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
+	r.Header.Set("event-type", "payment.void.create")
+	r.Header.Set("x-payments-os-env", "test")
+	r.Header.Set("x-zooz-request-id", "test-zooz-request-id")
+	r.Header.Set("signature", "sig1=iaminvalid")
+
+	_, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	require.Error(t, err)
+	require.True(t, errors.As(err, &zooz.ErrBadRequest{}))
+	require.Contains(t, err.Error(), `incorrect signature`)
+}
+
+func TestCalculateWebhookSignature_AllFields(t *testing.T) {
+	const (
+		privateKey = "test-private-key"
+
+		eventType                      = "payment.authorization.create"
+		id                             = "test-id"
+		created                        = "2018-10-03T05:14:17.196Z"
+		accountID                      = "test-account-id"
+		appID                          = "test-app-id"
+		paymentID                      = "test-payment-id"
+		data_ID                        = "test-transaction-id"
+		data_Result_Status             = "Pending"
+		data_Result_Category           = "payment_method_declined"
+		data_Result_SubCategory        = "declined_by_issuing_bank"
+		data_ProviderData_ResponseCode = "124"
+		data_ReconciliationID          = "test-reconciliation-id"
+		data_Amount                    = "42"
+		data_Currency                  = "RUB"
+	)
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, id string) ([]byte, error) {
+		require.Equal(t, appID, id)
+		return []byte(privateKey), nil
+	})
+
+	body := `{
+	"id": "` + id + `",
+    "created": "` + created + `",
+    "account_id": "` + accountID + `",
+    "app_id": "` + appID + `",
+    "payment_id": "` + paymentID + `",
+	"data": {
+		"id": "` + data_ID + `",
+  		"result": {
+			"status": "` + data_Result_Status + `",
+    		"category": "` + data_Result_Category + `",
+    		"sub_category": "` + data_Result_SubCategory + `"
+  		},
+  		"provider_data": {
+    		"response_code": "` + data_ProviderData_ResponseCode + `"
+  		},
+		"reconciliation_id": "` + data_ReconciliationID + `",
+		"amount": ` + data_Amount + `,
+		"currency": "` + data_Currency + `"
+	}
+}`
+	h := http.Header{}
+	h.Set("event-type", eventType)
+
+	sign, err := zooz.CalculateWebhookSignature(context.Background(), []byte(body), h, keyProvider)
+	require.NoError(t, err)
+	// double check that all signature fields are covered
+	require.Equal(t,
+		signature([]string{
+			eventType,
+			id,
+			accountID,
+			paymentID,
+			created,
+			appID,
+			data_ID,
+			data_Result_Status,
+			data_Result_Category,
+			data_Result_SubCategory,
+			data_ProviderData_ResponseCode,
+			data_ReconciliationID,
+			data_Amount,
+			data_Currency,
+		}, privateKey),
+		sign)
+	require.Equal(t, "b5457f3a7c7e8bdeea150485240b0a2c041f63d7ec5460c186ccde1e18453c3d", sign)
+}
+
+func TestCalculateWebhookSignature_MissingFields(t *testing.T) {
+	const (
+		privateKey = "test-private-key"
+
+		eventType                      = "payment.authorization.create"
+		id                             = "test-id"
+		created                        = "2018-10-03T05:14:17.196Z"
+		accountID                      = "test-account-id"
+		appID                          = "test-app-id"
+		paymentID                      = "test-app-id"
+		data_ID                        = "test-transaction-id"
+		data_Result_Status             = "Pending"
+		data_ProviderData_ResponseCode = "124"
+		data_ReconciliationID          = "test-reconciliation-id"
+	)
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, id string) ([]byte, error) {
+		require.Equal(t, appID, id)
+		return []byte(privateKey), nil
+	})
+
+	body := `{
+	"id": "` + id + `",
+    "created": "` + created + `",
+    "account_id": "` + accountID + `",
+    "app_id": "` + appID + `",
+    "payment_id": "` + paymentID + `",
+	"data": {
+		"id": "` + data_ID + `",
+  		"result": {
+			"status": "` + data_Result_Status + `",
+    		"category": ""
+  		},
+  		"provider_data": {
+    		"response_code": "` + data_ProviderData_ResponseCode + `"
+  		},
+		"reconciliation_id": "` + data_ReconciliationID + `"
+	}
+}`
+	h := http.Header{}
+	h.Set("event-type", eventType)
+
+	sign, err := zooz.CalculateWebhookSignature(context.Background(), []byte(body), h, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t,
+		signature([]string{
+			eventType,
+			id,
+			accountID,
+			paymentID,
+			created,
+			appID,
+			data_ID,
+			data_Result_Status,
+			"", // empty category
+			"", // missing subcategory
+			data_ProviderData_ResponseCode,
+			data_ReconciliationID,
+			"", // no amount
+			"", // no currency
+		}, privateKey),
+		sign)
+	require.Equal(t, "f4a3827af9a1d3a33e33db9dc226e54c676e46295e2e27c3a8115280def4f21c", sign)
+}
+
+func TestCalculateWebhookSignature_NoAmount(t *testing.T) {
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
+		require.Equal(t, "test-app-id", appID)
+		return []byte("test-private-key"), nil
+	})
+
+	body := `{
+	"id": "test-id",
+    "created": "2018-10-03T05:14:17.196Z",
+    "account_id": "test-account-id",
+    "app_id": "test-app-id",
+    "payment_id": "test-payment-id",
+	"data": {
+		"id": "test-transaction-id",
+  		"result": {
+			"status": "Pending",
+    		"category": "payment_method_declined",
+    		"sub_category": "declined_by_issuing_bank"
+  		},
+  		"provider_data": {
+    		"response_code": "124"
+  		},
+		"reconciliation_id": "test-reconciliation-id",
+		"currency": "RUB"
+	}
+}`
+	h := http.Header{}
+	h.Set("event-type", "payment.void.create")
+
+	sign, err := zooz.CalculateWebhookSignature(context.Background(), []byte(body), h, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t, "a7e5661bb528f36271142af2c935fdd12865f83919d0a8c5051023ee55339f82", sign)
+}
+
+func TestCalculateWebhookSignature_ZeroAmount(t *testing.T) {
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
+		require.Equal(t, "test-app-id", appID)
+		return []byte("test-private-key"), nil
+	})
+
+	body := `{
+	"id": "test-id",
+    "created": "2018-10-03T05:14:17.196Z",
+    "account_id": "test-account-id",
+    "app_id": "test-app-id",
+    "payment_id": "test-app-id",
+	"data": {
+		"id": "test-transaction-id",
+  		"result": {
+			"status": "Pending",
+    		"category": "payment_method_declined",
+    		"sub_category": "declined_by_issuing_bank"
+  		},
+  		"provider_data": {
+    		"response_code": "124"
+  		},
+		"reconciliation_id": "test-reconciliation-id",
+		"amount": 0,
+		"currency": "RUB"
+	}
+}`
+	h := http.Header{}
+	h.Set("event-type", "payment.authorization.create")
+
+	sign, err := zooz.CalculateWebhookSignature(context.Background(), []byte(body), h, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t, "bb5ce0186b035d21a7dbb23958873082f453acf19b29f7a939cfddf61926acf8", sign)
+}
+
+// was validated via zooz sandbox
+func TestCalculateWebhookSignature_Payment(t *testing.T) {
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
+		require.Equal(t, "com.gojuno.gett_development", appID)
+		return []byte("test-private-key"), nil
+	})
+
+	body := `{
+	"id": "150f1279-6d2c-4728-9e23-6b303f3f1f2f-2020-11-06T14:33:46.150Z-fe14a744-ade7-4a15-8df4-a0b12ac11590",
+    "created": "2020-11-06T14:33:46.150Z",
+    "account_id": "2058ac1f-ca4b-497f-8181-341e0eea5392",
+    "app_id": "com.gojuno.gett_development",
+	"payment_id": "150f1279-6d2c-4728-9e23-6b303f3f1f2f",
+	"data": {
+		"id": "150f1279-6d2c-4728-9e23-6b303f3f1f2f",
+		"amount": 100,
+		"currency": "RUB"
+	}
+}`
+	h := http.Header{}
+	h.Set("event-type", "payment.payment.create")
+
+	sign, err := zooz.CalculateWebhookSignature(context.Background(), []byte(body), h, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t, "a74ee728238d42eef7bed9e832eba5b9ab9d95d487027610b8ae50557f09cd05", sign)
+}
+
+// was validated via zooz sandbox
+func TestCalculateWebhookSignature_Void(t *testing.T) {
+	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
+		require.Equal(t, "com.gojuno.gett_development", appID)
+		return []byte("test-private-key"), nil
+	})
+
+	body := `{
+	"id": "83bc25f0-1710-4ea7-b610-8028f4de6d63-2020-11-06T21:09:22.356Z-fe14a744-ade7-4a15-8df4-a0b12ac11590",
+    "created": "2020-11-06T21:09:22.356Z",
+    "account_id": "2058ac1f-ca4b-497f-8181-341e0eea5392",
+    "app_id": "com.gojuno.gett_development",
+	"payment_id": "83bc25f0-1710-4ea7-b610-8028f4de6d63",
+	"data": {
+		"id": "c5f5ade4-674f-481e-a119-5827a095d352",
+		"result": {
+			"status": "Succeed"
+		},
+  		"provider_data": {
+    		"response_code": "0"
+  		}
+	}
+}`
+	h := http.Header{}
+	h.Set("event-type", "payment.void.create")
+
+	sign, err := zooz.CalculateWebhookSignature(context.Background(), []byte(body), h, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t, "e2113f4e1728128b18ae945933f8f3e2b01d1e07d2bd8395688109cb18942377", sign)
+}
+
+func signature(values []string, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	if _, err := mac.Write([]byte(strings.Join(values, ","))); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func calcRequestSignature(t *testing.T, keyProvider zooz.PrivateKeyProviderFunc, reqBody []byte, reqHeader http.Header) string {
+	signature, err := zooz.CalculateWebhookSignature(context.Background(), reqBody, reqHeader, keyProvider)
+	require.NoError(t, err)
+	return "sig1=" + signature
+}

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -18,12 +18,9 @@ import (
 )
 
 func TestDecodeWebhookRequest_Payment(t *testing.T) {
-	const eventType = "payment.payment.create"
-	const privateKey = "test-private-key"
-
 	expected := zooz.PaymentCallback{
 		CallbackCommon: zooz.CallbackCommon{
-			EventType:      eventType,
+			EventType:      "payment.payment.create",
 			XPaymentsOSEnv: "live",
 			XZoozRequestID: "test-x-zooz-request-id",
 
@@ -44,10 +41,7 @@ func TestDecodeWebhookRequest_Payment(t *testing.T) {
 		},
 	}
 
-	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
-		require.Equal(t, expected.AppID, appID)
-		return []byte(privateKey), nil
-	})
+	keyProvider := zooz.FixedPrivateKeyProvider{expected.AppID: []byte("test-private-key")}
 
 	body :=
 		`{
@@ -65,7 +59,7 @@ func TestDecodeWebhookRequest_Payment(t *testing.T) {
 	}
 }`
 	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
-	r.Header.Set("event-type", eventType)
+	r.Header.Set("event-type", expected.EventType)
 	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
 	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
 	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
@@ -76,12 +70,9 @@ func TestDecodeWebhookRequest_Payment(t *testing.T) {
 }
 
 func TestDecodeWebhookRequest_Authorization(t *testing.T) {
-	const eventType = "payment.authorization.create"
-	const privateKey = "test-private-key"
-
 	expected := zooz.AuthorizationCallback{
 		CallbackCommon: zooz.CallbackCommon{
-			EventType:      eventType,
+			EventType:      "payment.authorization.create",
 			XPaymentsOSEnv: "live",
 			XZoozRequestID: "test-x-zooz-request-id",
 
@@ -108,10 +99,7 @@ func TestDecodeWebhookRequest_Authorization(t *testing.T) {
 		},
 	}
 
-	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
-		require.Equal(t, expected.AppID, appID)
-		return []byte(privateKey), nil
-	})
+	keyProvider := zooz.FixedPrivateKeyProvider{expected.AppID: []byte("test-private-key")}
 
 	body :=
 		`{
@@ -137,7 +125,7 @@ func TestDecodeWebhookRequest_Authorization(t *testing.T) {
 	}
 }`
 	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
-	r.Header.Set("event-type", eventType)
+	r.Header.Set("event-type", expected.EventType)
 	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
 	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
 	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
@@ -148,12 +136,9 @@ func TestDecodeWebhookRequest_Authorization(t *testing.T) {
 }
 
 func TestDecodeWebhookRequest_Capture(t *testing.T) {
-	const eventType = "payment.capture.update"
-	const privateKey = "test-private-key"
-
 	expected := zooz.CaptureCallback{
 		CallbackCommon: zooz.CallbackCommon{
-			EventType:      eventType,
+			EventType:      "payment.capture.update",
 			XPaymentsOSEnv: "live",
 			XZoozRequestID: "test-x-zooz-request-id",
 
@@ -182,10 +167,7 @@ func TestDecodeWebhookRequest_Capture(t *testing.T) {
 		},
 	}
 
-	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
-		require.Equal(t, expected.AppID, appID)
-		return []byte(privateKey), nil
-	})
+	keyProvider := zooz.FixedPrivateKeyProvider{expected.AppID: []byte("test-private-key")}
 
 	body :=
 		`{
@@ -211,7 +193,7 @@ func TestDecodeWebhookRequest_Capture(t *testing.T) {
 	}
 }`
 	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
-	r.Header.Set("event-type", eventType)
+	r.Header.Set("event-type", expected.EventType)
 	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
 	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
 	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
@@ -222,12 +204,9 @@ func TestDecodeWebhookRequest_Capture(t *testing.T) {
 }
 
 func TestDecodeWebhookRequest_Void(t *testing.T) {
-	const eventType = "payment.void.create"
-	const privateKey = "test-private-key"
-
 	expected := zooz.VoidCallback{
 		CallbackCommon: zooz.CallbackCommon{
-			EventType:      eventType,
+			EventType:      "payment.void.create",
 			XPaymentsOSEnv: "live",
 			XZoozRequestID: "test-x-zooz-request-id",
 
@@ -252,10 +231,7 @@ func TestDecodeWebhookRequest_Void(t *testing.T) {
 		},
 	}
 
-	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
-		require.Equal(t, expected.AppID, appID)
-		return []byte(privateKey), nil
-	})
+	keyProvider := zooz.FixedPrivateKeyProvider{expected.AppID: []byte("test-private-key")}
 
 	body :=
 		`{
@@ -279,7 +255,7 @@ func TestDecodeWebhookRequest_Void(t *testing.T) {
 	}
 }`
 	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
-	r.Header.Set("event-type", eventType)
+	r.Header.Set("event-type", expected.EventType)
 	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
 	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
 	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
@@ -290,20 +266,16 @@ func TestDecodeWebhookRequest_Void(t *testing.T) {
 }
 
 func TestDecodeWebhookRequest_Refund(t *testing.T) {
-	const eventType = "payment.refund.update"
-	const appID = "test-app-id"
-	const privateKey = "test-private-key"
-
 	expected := zooz.RefundCallback{
 		CallbackCommon: zooz.CallbackCommon{
-			EventType:      eventType,
+			EventType:      "payment.refund.update",
 			XPaymentsOSEnv: "live",
 			XZoozRequestID: "test-x-zooz-request-id",
 
 			ID:        "test-webhook-id",
 			Created:   time.Date(2018, 10, 03, 05, 22, 45, 610000000, time.UTC), // "2018-10-03T05:22:45.610Z"
 			AccountID: "test-account-id",
-			AppID:     appID,
+			AppID:     "test-app-id",
 			PaymentID: "test-payment-id",
 		},
 		Data: zooz.Refund{
@@ -327,10 +299,7 @@ func TestDecodeWebhookRequest_Refund(t *testing.T) {
 		},
 	}
 
-	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
-		require.Equal(t, "test-app-id", appID)
-		return []byte(privateKey), nil
-	})
+	keyProvider := zooz.FixedPrivateKeyProvider{expected.AppID: []byte("test-private-key")}
 
 	body :=
 		`{
@@ -358,7 +327,7 @@ func TestDecodeWebhookRequest_Refund(t *testing.T) {
 	}
 }`
 	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
-	r.Header.Set("event-type", eventType)
+	r.Header.Set("event-type", expected.EventType)
 	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
 	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
 	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
@@ -369,10 +338,7 @@ func TestDecodeWebhookRequest_Refund(t *testing.T) {
 }
 
 func TestDecodeWebhookRequest_BadRequestError_BrokenJson(t *testing.T) {
-	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
-		require.Equal(t, "test-app-id", appID)
-		return []byte("test-private-key"), nil
-	})
+	keyProvider := zooz.FixedPrivateKeyProvider{"test-app-id": []byte("test-private-key")}
 
 	body := `{
 			"id": "test-webhook-id",
@@ -382,8 +348,6 @@ func TestDecodeWebhookRequest_BadRequestError_BrokenJson(t *testing.T) {
 `
 	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
 	r.Header.Set("event-type", "payment.void.create")
-	r.Header.Set("x-payments-os-env", "test")
-	r.Header.Set("x-zooz-request-id", "test-zooz-request-id")
 	r.Header.Set("signature", "sig1=doesntmatter")
 
 	_, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
@@ -393,10 +357,7 @@ func TestDecodeWebhookRequest_BadRequestError_BrokenJson(t *testing.T) {
 }
 
 func TestDecodeWebhookRequest_BadRequestError_UnsupportedEventType(t *testing.T) {
-	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
-		require.Equal(t, "test-app-id", appID)
-		return []byte("test-private-key"), nil
-	})
+	keyProvider := zooz.FixedPrivateKeyProvider{"test-app-id": []byte("test-private-key")}
 
 	body :=
 		`{
@@ -418,8 +379,6 @@ func TestDecodeWebhookRequest_BadRequestError_UnsupportedEventType(t *testing.T)
 }`
 	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
 	r.Header.Set("event-type", "payment.XXXX.create")
-	r.Header.Set("x-payments-os-env", "test")
-	r.Header.Set("x-zooz-request-id", "test-zooz-request-id")
 	r.Header.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), r.Header))
 
 	_, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
@@ -429,17 +388,14 @@ func TestDecodeWebhookRequest_BadRequestError_UnsupportedEventType(t *testing.T)
 }
 
 func TestDecodeWebhookRequest_BadRequestError_UnknownBusinessUnit(t *testing.T) {
-	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
-		require.Equal(t, "test-app-id", appID)
-		return nil, nil // pretend we don't know this business unit
-	})
+	keyProvider := zooz.FixedPrivateKeyProvider{"test-app-id": []byte("test-private-key")} // we don't know 'UNKNOWN-app-id'
 
 	body :=
 		`{
 	"id": "test-webhook-id",
     "created": "2018-10-03T05:14:17.196Z",
     "account_id": "test-account-id",
-    "app_id": "test-app-id",
+    "app_id": "UNKNOWN-app-id",
     "payment_id": "test-payment-id",
 	"data": {
 		"id": "test-transaction-id",
@@ -454,21 +410,16 @@ func TestDecodeWebhookRequest_BadRequestError_UnknownBusinessUnit(t *testing.T) 
 }`
 	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
 	r.Header.Set("event-type", "payment.void.create")
-	r.Header.Set("x-payments-os-env", "test")
-	r.Header.Set("x-zooz-request-id", "test-zooz-request-id")
 	r.Header.Set("signature", "sig1=doesntmatter")
 
 	_, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
 	require.Error(t, err)
 	require.True(t, errors.As(err, &zooz.ErrBadRequest{}))
-	require.Contains(t, err.Error(), `unknown app_id "test-app-id"`)
+	require.Contains(t, err.Error(), `unknown app_id "UNKNOWN-app-id"`)
 }
 
 func TestDecodeWebhookRequest_BadRequestError_IncorrectSignature(t *testing.T) {
-	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
-		require.Equal(t, "test-app-id", appID)
-		return []byte("test-private-key"), nil
-	})
+	keyProvider := zooz.FixedPrivateKeyProvider{"test-app-id": []byte("test-private-key")}
 
 	body :=
 		`{
@@ -490,8 +441,6 @@ func TestDecodeWebhookRequest_BadRequestError_IncorrectSignature(t *testing.T) {
 }`
 	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
 	r.Header.Set("event-type", "payment.void.create")
-	r.Header.Set("x-payments-os-env", "test")
-	r.Header.Set("x-zooz-request-id", "test-zooz-request-id")
 	r.Header.Set("signature", "sig1=iaminvalid")
 
 	_, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
@@ -520,10 +469,7 @@ func TestCalculateWebhookSignature_AllFields(t *testing.T) {
 		data_Currency                  = "RUB"
 	)
 
-	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, id string) ([]byte, error) {
-		require.Equal(t, appID, id)
-		return []byte(privateKey), nil
-	})
+	keyProvider := zooz.FixedPrivateKeyProvider{appID: []byte(privateKey)}
 
 	body := `{
 	"id": "` + id + `",
@@ -589,10 +535,7 @@ func TestCalculateWebhookSignature_MissingFields(t *testing.T) {
 		data_ReconciliationID          = "test-reconciliation-id"
 	)
 
-	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, id string) ([]byte, error) {
-		require.Equal(t, appID, id)
-		return []byte(privateKey), nil
-	})
+	keyProvider := zooz.FixedPrivateKeyProvider{appID: []byte(privateKey)}
 
 	body := `{
 	"id": "` + id + `",
@@ -639,10 +582,7 @@ func TestCalculateWebhookSignature_MissingFields(t *testing.T) {
 }
 
 func TestCalculateWebhookSignature_NoAmount(t *testing.T) {
-	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
-		require.Equal(t, "test-app-id", appID)
-		return []byte("test-private-key"), nil
-	})
+	keyProvider := zooz.FixedPrivateKeyProvider{"test-app-id": []byte("test-private-key")}
 
 	body := `{
 	"id": "test-id",
@@ -709,10 +649,7 @@ func TestCalculateWebhookSignature_ZeroAmount(t *testing.T) {
 
 // was validated via zooz sandbox
 func TestCalculateWebhookSignature_Payment(t *testing.T) {
-	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
-		require.Equal(t, "com.gojuno.gett_development", appID)
-		return []byte("test-private-key"), nil
-	})
+	keyProvider := zooz.FixedPrivateKeyProvider{"com.gojuno.gett_development": []byte("test-private-key")}
 
 	body := `{
 	"id": "150f1279-6d2c-4728-9e23-6b303f3f1f2f-2020-11-06T14:33:46.150Z-fe14a744-ade7-4a15-8df4-a0b12ac11590",
@@ -736,10 +673,7 @@ func TestCalculateWebhookSignature_Payment(t *testing.T) {
 
 // was validated via zooz sandbox
 func TestCalculateWebhookSignature_Void(t *testing.T) {
-	keyProvider := zooz.PrivateKeyProviderFunc(func(_ context.Context, appID string) ([]byte, error) {
-		require.Equal(t, "com.gojuno.gett_development", appID)
-		return []byte("test-private-key"), nil
-	})
+	keyProvider := zooz.FixedPrivateKeyProvider{"com.gojuno.gett_development": []byte("test-private-key")}
 
 	body := `{
 	"id": "83bc25f0-1710-4ea7-b610-8028f4de6d63-2020-11-06T21:09:22.356Z-fe14a744-ade7-4a15-8df4-a0b12ac11590",
@@ -773,7 +707,13 @@ func signature(values []string, key string) string {
 	return hex.EncodeToString(mac.Sum(nil))
 }
 
-func calcRequestSignature(t *testing.T, keyProvider zooz.PrivateKeyProviderFunc, reqBody []byte, reqHeader http.Header) string {
+func calcRequestSignature(t *testing.T,
+	keyProvider interface {
+		PrivateKey(ctx context.Context, appID string) ([]byte, error)
+	},
+	reqBody []byte,
+	reqHeader http.Header,
+) string {
 	signature, err := zooz.CalculateWebhookSignature(context.Background(), reqBody, reqHeader, keyProvider)
 	require.NoError(t, err)
 	return "sig1=" + signature

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -42,21 +42,20 @@ func TestDecodeWebhookRequest_Payment(t *testing.T) {
 
 	keyProvider := zooz.FixedPrivateKeyProvider{expected.AppID: []byte("test-private-key")}
 
-	body :=
-		`{
-	"id": "` + expected.ID + `",
-    "created": "2018-10-03T04:58:35.385Z",
-    "account_id": "` + expected.AccountID + `",
-    "app_id": "` + expected.AppID + `",
-    "payment_id": "` + expected.PaymentID + `",
-	"data": {
-		"id": "` + expected.Data.ID + `",
-		"status": "` + string(expected.Data.Status) + `",
-  		"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
-		"currency":"` + expected.Data.Currency + `",
-		"customer_id": "` + expected.Data.CustomerID + `"
-	}
-}`
+	body := `{
+		"id": "` + expected.ID + `",
+		"created": "2018-10-03T04:58:35.385Z",
+		"account_id": "` + expected.AccountID + `",
+		"app_id": "` + expected.AppID + `",
+		"payment_id": "` + expected.PaymentID + `",
+		"data": {
+			"id": "` + expected.Data.ID + `",
+			"status": "` + string(expected.Data.Status) + `",
+			"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
+			"currency":"` + expected.Data.Currency + `",
+			"customer_id": "` + expected.Data.CustomerID + `"
+		}
+	}`
 	h := http.Header{}
 	h.Set("event-type", expected.EventType)
 	h.Set("x-payments-os-env", expected.XPaymentsOSEnv)
@@ -100,29 +99,28 @@ func TestDecodeWebhookRequest_Authorization(t *testing.T) {
 
 	keyProvider := zooz.FixedPrivateKeyProvider{expected.AppID: []byte("test-private-key")}
 
-	body :=
-		`{
-	"id": "` + expected.ID + `",
-    "created": "2018-10-03T04:58:35.385Z",
-    "account_id": "` + expected.AccountID + `",
-    "app_id": "` + expected.AppID + `",
-    "payment_id": "` + expected.PaymentID + `",
-	"data": {
-		"id": "` + expected.Data.ID + `",
-  		"result": {
-			"status": "` + expected.Data.Result.Status + `",
-    		"category": "` + expected.Data.Result.Category + `",
-    		"sub_category": "` + expected.Data.Result.SubCategory + `",
-    		"description": "` + expected.Data.Result.Description + `"
-  		},
-  		"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
-  		"reconciliation_id": "` + expected.Data.ReconciliationID + `",
-  		"provider_data": {
-    		"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
-    		"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
-  		}
-	}
-}`
+	body := `{
+		"id": "` + expected.ID + `",
+		"created": "2018-10-03T04:58:35.385Z",
+		"account_id": "` + expected.AccountID + `",
+		"app_id": "` + expected.AppID + `",
+		"payment_id": "` + expected.PaymentID + `",
+		"data": {
+			"id": "` + expected.Data.ID + `",
+			"result": {
+				"status": "` + expected.Data.Result.Status + `",
+				"category": "` + expected.Data.Result.Category + `",
+				"sub_category": "` + expected.Data.Result.SubCategory + `",
+				"description": "` + expected.Data.Result.Description + `"
+			},
+			"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
+			"reconciliation_id": "` + expected.Data.ReconciliationID + `",
+			"provider_data": {
+				"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
+				"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
+			}
+		}
+	}`
 	h := http.Header{}
 	h.Set("event-type", expected.EventType)
 	h.Set("x-payments-os-env", expected.XPaymentsOSEnv)
@@ -168,29 +166,28 @@ func TestDecodeWebhookRequest_Capture(t *testing.T) {
 
 	keyProvider := zooz.FixedPrivateKeyProvider{expected.AppID: []byte("test-private-key")}
 
-	body :=
-		`{
-	"id": "` + expected.ID + `",
-    "created": "2018-10-03T05:14:17.196Z",
-    "account_id": "` + expected.AccountID + `",
-    "app_id": "` + expected.AppID + `",
-    "payment_id": "` + expected.PaymentID + `",
-	"data": {
-		"id": "` + expected.Data.ID + `",
-  		"result": {
-			"status": "` + expected.Data.Result.Status + `",
-    		"category": "` + expected.Data.Result.Category + `",
-    		"sub_category": "` + expected.Data.Result.SubCategory + `",
-    		"description": "` + expected.Data.Result.Description + `"
-  		},
-  		"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
-  		"reconciliation_id": "` + expected.Data.ReconciliationID + `",
-  		"provider_data": {
-    		"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
-    		"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
-  		}
-	}
-}`
+	body := `{
+		"id": "` + expected.ID + `",
+		"created": "2018-10-03T05:14:17.196Z",
+		"account_id": "` + expected.AccountID + `",
+		"app_id": "` + expected.AppID + `",
+		"payment_id": "` + expected.PaymentID + `",
+		"data": {
+			"id": "` + expected.Data.ID + `",
+			"result": {
+				"status": "` + expected.Data.Result.Status + `",
+				"category": "` + expected.Data.Result.Category + `",
+				"sub_category": "` + expected.Data.Result.SubCategory + `",
+				"description": "` + expected.Data.Result.Description + `"
+			},
+			"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
+			"reconciliation_id": "` + expected.Data.ReconciliationID + `",
+			"provider_data": {
+				"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
+				"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
+			}
+		}
+	}`
 	h := http.Header{}
 	h.Set("event-type", expected.EventType)
 	h.Set("x-payments-os-env", expected.XPaymentsOSEnv)
@@ -232,27 +229,26 @@ func TestDecodeWebhookRequest_Void(t *testing.T) {
 
 	keyProvider := zooz.FixedPrivateKeyProvider{expected.AppID: []byte("test-private-key")}
 
-	body :=
-		`{
-	"id": "` + expected.ID + `",
-    "created": "2018-10-03T05:14:17.196Z",
-    "account_id": "` + expected.AccountID + `",
-    "app_id": "` + expected.AppID + `",
-    "payment_id": "` + expected.PaymentID + `",
-	"data": {
-		"id": "` + expected.Data.ID + `",
-  		"result": {
-			"status": "` + expected.Data.Result.Status + `",
-    		"category": "` + expected.Data.Result.Category + `",
-    		"sub_category": "` + expected.Data.Result.SubCategory + `",
-    		"description": "` + expected.Data.Result.Description + `"
-  		},
-  		"provider_data": {
-    		"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
-    		"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
-  		}
-	}
-}`
+	body := `{
+		"id": "` + expected.ID + `",
+		"created": "2018-10-03T05:14:17.196Z",
+		"account_id": "` + expected.AccountID + `",
+		"app_id": "` + expected.AppID + `",
+		"payment_id": "` + expected.PaymentID + `",
+		"data": {
+			"id": "` + expected.Data.ID + `",
+			"result": {
+				"status": "` + expected.Data.Result.Status + `",
+				"category": "` + expected.Data.Result.Category + `",
+				"sub_category": "` + expected.Data.Result.SubCategory + `",
+				"description": "` + expected.Data.Result.Description + `"
+			},
+			"provider_data": {
+				"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
+				"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
+			}
+		}
+	}`
 	h := http.Header{}
 	h.Set("event-type", expected.EventType)
 	h.Set("x-payments-os-env", expected.XPaymentsOSEnv)
@@ -300,31 +296,30 @@ func TestDecodeWebhookRequest_Refund(t *testing.T) {
 
 	keyProvider := zooz.FixedPrivateKeyProvider{expected.AppID: []byte("test-private-key")}
 
-	body :=
-		`{
-	"id": "` + expected.ID + `",
-    "created": "2018-10-03T05:22:45.610Z",
-    "account_id": "` + expected.AccountID + `",
-    "app_id": "` + expected.AppID + `",
-    "payment_id": "` + expected.PaymentID + `",
-	"data": {
-		"id": "` + expected.Data.ID + `",
-  		"result": {
-			"status": "` + expected.Data.Result.Status + `",
-    		"category": "` + expected.Data.Result.Category + `",
-    		"sub_category": "` + expected.Data.Result.SubCategory + `",
-    		"description": "` + expected.Data.Result.Description + `"
-  		},
-  		"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
-  		"reconciliation_id": "` + expected.Data.ReconciliationID + `",
-		"capture_id": "` + expected.Data.CaptureID + `",
-		"reason": "` + expected.Data.Reason + `",
-  		"provider_data": {
-    		"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
-    		"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
-  		}
-	}
-}`
+	body := `{
+		"id": "` + expected.ID + `",
+		"created": "2018-10-03T05:22:45.610Z",
+		"account_id": "` + expected.AccountID + `",
+		"app_id": "` + expected.AppID + `",
+		"payment_id": "` + expected.PaymentID + `",
+		"data": {
+			"id": "` + expected.Data.ID + `",
+			"result": {
+				"status": "` + expected.Data.Result.Status + `",
+				"category": "` + expected.Data.Result.Category + `",
+				"sub_category": "` + expected.Data.Result.SubCategory + `",
+				"description": "` + expected.Data.Result.Description + `"
+  			},
+  			"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
+			"reconciliation_id": "` + expected.Data.ReconciliationID + `",
+			"capture_id": "` + expected.Data.CaptureID + `",
+			"reason": "` + expected.Data.Reason + `",
+			"provider_data": {
+				"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
+				"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
+			}
+		}
+	}`
 	h := http.Header{}
 	h.Set("event-type", expected.EventType)
 	h.Set("x-payments-os-env", expected.XPaymentsOSEnv)
@@ -340,10 +335,10 @@ func TestDecodeWebhookRequest_BadRequestError_BrokenJson(t *testing.T) {
 	keyProvider := zooz.FixedPrivateKeyProvider{"test-app-id": []byte("test-private-key")}
 
 	body := `{
-			"id": "test-webhook-id",
-    		"created": "2018-10-03T05:22:45.610Z",
-    		"account_id": "test-account-id",
-    		"app_id": "test-app-id",
+		"id": "test-webhook-id",
+		"created": "2018-10-03T05:22:45.610Z",
+		"account_id": "test-account-id",
+		"app_id": "test-app-id",
 `
 	h := http.Header{}
 	h.Set("event-type", "payment.void.create")
@@ -358,24 +353,23 @@ func TestDecodeWebhookRequest_BadRequestError_BrokenJson(t *testing.T) {
 func TestDecodeWebhookRequest_BadRequestError_UnsupportedEventType(t *testing.T) {
 	keyProvider := zooz.FixedPrivateKeyProvider{"test-app-id": []byte("test-private-key")}
 
-	body :=
-		`{
-	"id": "test-webhook-id",
-    "created": "2018-10-03T05:14:17.196Z",
-    "account_id": "test-account-id",
-    "app_id": "test-app-id",
-    "payment_id": "test-payment-id",
-	"data": {
-		"id": "test-transaction-id",
-  		"result": {
-			"status": "Success"
-  		},
-  		"provider_data": {
-    		"provider_name": "test-provider-name",
-    		"response_code": "0"
-  		}
-	}
-}`
+	body := `{
+		"id": "test-webhook-id",
+		"created": "2018-10-03T05:14:17.196Z",
+		"account_id": "test-account-id",
+		"app_id": "test-app-id",
+		"payment_id": "test-payment-id",
+		"data": {
+			"id": "test-transaction-id",
+			"result": {
+				"status": "Success"
+			},
+			"provider_data": {
+				"provider_name": "test-provider-name",
+				"response_code": "0"
+			}
+		}
+	}`
 	h := http.Header{}
 	h.Set("event-type", "payment.XXXX.create")
 	h.Set("signature", calcRequestSignature(t, keyProvider, []byte(body), h))
@@ -389,24 +383,23 @@ func TestDecodeWebhookRequest_BadRequestError_UnsupportedEventType(t *testing.T)
 func TestDecodeWebhookRequest_BadRequestError_UnknownBusinessUnit(t *testing.T) {
 	keyProvider := zooz.FixedPrivateKeyProvider{"test-app-id": []byte("test-private-key")} // we don't know 'UNKNOWN-app-id'
 
-	body :=
-		`{
-	"id": "test-webhook-id",
-    "created": "2018-10-03T05:14:17.196Z",
-    "account_id": "test-account-id",
-    "app_id": "UNKNOWN-app-id",
-    "payment_id": "test-payment-id",
-	"data": {
-		"id": "test-transaction-id",
-  		"result": {
-			"status": "Success"
-  		},
-  		"provider_data": {
-    		"provider_name": "test-provider-name",
-    		"response_code": "0"
-  		}
-	}
-}`
+	body := `{
+		"id": "test-webhook-id",
+		"created": "2018-10-03T05:14:17.196Z",
+		"account_id": "test-account-id",
+		"app_id": "UNKNOWN-app-id",
+		"payment_id": "test-payment-id",
+		"data": {
+			"id": "test-transaction-id",
+			"result": {
+				"status": "Success"
+			},
+			"provider_data": {
+				"provider_name": "test-provider-name",
+				"response_code": "0"
+			}
+		}
+	}`
 	h := http.Header{}
 	h.Set("event-type", "payment.void.create")
 	h.Set("signature", "sig1=doesntmatter")
@@ -420,24 +413,23 @@ func TestDecodeWebhookRequest_BadRequestError_UnknownBusinessUnit(t *testing.T) 
 func TestDecodeWebhookRequest_BadRequestError_IncorrectSignature(t *testing.T) {
 	keyProvider := zooz.FixedPrivateKeyProvider{"test-app-id": []byte("test-private-key")}
 
-	body :=
-		`{
-	"id": "test-webhook-id",
-    "created": "2018-10-03T05:14:17.196Z",
-    "account_id": "test-account-id",
-    "app_id": "test-app-id",
-    "payment_id": "test-payment-id",
-	"data": {
-		"id": "test-transaction-id",
-  		"result": {
-			"status": "Success"
-  		},
-  		"provider_data": {
-    		"provider_name": "test-provider-name",
-    		"response_code": "0"
-  		}
-	}
-}`
+	body := `{
+		"id": "test-webhook-id",
+		"created": "2018-10-03T05:14:17.196Z",
+		"account_id": "test-account-id",
+		"app_id": "test-app-id",
+		"payment_id": "test-payment-id",
+		"data": {
+			"id": "test-transaction-id",
+			"result": {
+				"status": "Success"
+			},
+			"provider_data": {
+				"provider_name": "test-provider-name",
+				"response_code": "0"
+			}
+		}
+	}`
 	h := http.Header{}
 	h.Set("event-type", "payment.void.create")
 	h.Set("signature", "sig1=iaminvalid")
@@ -471,26 +463,26 @@ func TestCalculateWebhookSignature_AllFields(t *testing.T) {
 	keyProvider := zooz.FixedPrivateKeyProvider{appID: []byte(privateKey)}
 
 	body := `{
-	"id": "` + id + `",
-    "created": "` + created + `",
-    "account_id": "` + accountID + `",
-    "app_id": "` + appID + `",
-    "payment_id": "` + paymentID + `",
-	"data": {
-		"id": "` + data_ID + `",
-  		"result": {
-			"status": "` + data_Result_Status + `",
-    		"category": "` + data_Result_Category + `",
-    		"sub_category": "` + data_Result_SubCategory + `"
-  		},
-  		"provider_data": {
-    		"response_code": "` + data_ProviderData_ResponseCode + `"
-  		},
-		"reconciliation_id": "` + data_ReconciliationID + `",
-		"amount": ` + data_Amount + `,
-		"currency": "` + data_Currency + `"
-	}
-}`
+		"id": "` + id + `",
+		"created": "` + created + `",
+		"account_id": "` + accountID + `",
+		"app_id": "` + appID + `",
+		"payment_id": "` + paymentID + `",
+		"data": {
+			"id": "` + data_ID + `",
+			"result": {
+				"status": "` + data_Result_Status + `",
+				"category": "` + data_Result_Category + `",
+				"sub_category": "` + data_Result_SubCategory + `"
+			},
+			"provider_data": {
+				"response_code": "` + data_ProviderData_ResponseCode + `"
+			},
+			"reconciliation_id": "` + data_ReconciliationID + `",
+			"amount": ` + data_Amount + `,
+			"currency": "` + data_Currency + `"
+		}
+	}`
 	h := http.Header{}
 	h.Set("event-type", eventType)
 
@@ -537,23 +529,23 @@ func TestCalculateWebhookSignature_MissingFields(t *testing.T) {
 	keyProvider := zooz.FixedPrivateKeyProvider{appID: []byte(privateKey)}
 
 	body := `{
-	"id": "` + id + `",
-    "created": "` + created + `",
-    "account_id": "` + accountID + `",
-    "app_id": "` + appID + `",
-    "payment_id": "` + paymentID + `",
-	"data": {
-		"id": "` + data_ID + `",
-  		"result": {
-			"status": "` + data_Result_Status + `",
-    		"category": ""
-  		},
-  		"provider_data": {
-    		"response_code": "` + data_ProviderData_ResponseCode + `"
-  		},
-		"reconciliation_id": "` + data_ReconciliationID + `"
-	}
-}`
+		"id": "` + id + `",
+		"created": "` + created + `",
+		"account_id": "` + accountID + `",
+		"app_id": "` + appID + `",
+		"payment_id": "` + paymentID + `",
+		"data": {
+			"id": "` + data_ID + `",
+			"result": {
+				"status": "` + data_Result_Status + `",
+				"category": ""
+			},
+			"provider_data": {
+				"response_code": "` + data_ProviderData_ResponseCode + `"
+			},
+			"reconciliation_id": "` + data_ReconciliationID + `"
+		}
+	}`
 	h := http.Header{}
 	h.Set("event-type", eventType)
 
@@ -584,25 +576,25 @@ func TestCalculateWebhookSignature_NoAmount(t *testing.T) {
 	keyProvider := zooz.FixedPrivateKeyProvider{"test-app-id": []byte("test-private-key")}
 
 	body := `{
-	"id": "test-id",
-    "created": "2018-10-03T05:14:17.196Z",
-    "account_id": "test-account-id",
-    "app_id": "test-app-id",
-    "payment_id": "test-payment-id",
-	"data": {
-		"id": "test-transaction-id",
-  		"result": {
-			"status": "Pending",
-    		"category": "payment_method_declined",
-    		"sub_category": "declined_by_issuing_bank"
-  		},
-  		"provider_data": {
-    		"response_code": "124"
-  		},
-		"reconciliation_id": "test-reconciliation-id",
-		"currency": "RUB"
-	}
-}`
+		"id": "test-id",
+		"created": "2018-10-03T05:14:17.196Z",
+		"account_id": "test-account-id",
+		"app_id": "test-app-id",
+		"payment_id": "test-payment-id",
+		"data": {
+			"id": "test-transaction-id",
+			"result": {
+				"status": "Pending",
+				"category": "payment_method_declined",
+				"sub_category": "declined_by_issuing_bank"
+			},
+			"provider_data": {
+				"response_code": "124"
+			},
+			"reconciliation_id": "test-reconciliation-id",
+			"currency": "RUB"
+		}
+	}`
 	h := http.Header{}
 	h.Set("event-type", "payment.void.create")
 
@@ -618,26 +610,26 @@ func TestCalculateWebhookSignature_ZeroAmount(t *testing.T) {
 	})
 
 	body := `{
-	"id": "test-id",
-    "created": "2018-10-03T05:14:17.196Z",
-    "account_id": "test-account-id",
-    "app_id": "test-app-id",
-    "payment_id": "test-app-id",
-	"data": {
-		"id": "test-transaction-id",
-  		"result": {
-			"status": "Pending",
-    		"category": "payment_method_declined",
-    		"sub_category": "declined_by_issuing_bank"
-  		},
-  		"provider_data": {
-    		"response_code": "124"
-  		},
-		"reconciliation_id": "test-reconciliation-id",
-		"amount": 0,
-		"currency": "RUB"
-	}
-}`
+		"id": "test-id",
+		"created": "2018-10-03T05:14:17.196Z",
+		"account_id": "test-account-id",
+		"app_id": "test-app-id",
+		"payment_id": "test-app-id",
+		"data": {
+			"id": "test-transaction-id",
+			"result": {
+				"status": "Pending",
+				"category": "payment_method_declined",
+				"sub_category": "declined_by_issuing_bank"
+			},
+			"provider_data": {
+				"response_code": "124"
+			},
+			"reconciliation_id": "test-reconciliation-id",
+			"amount": 0,
+			"currency": "RUB"
+		}
+	}`
 	h := http.Header{}
 	h.Set("event-type", "payment.authorization.create")
 
@@ -651,17 +643,17 @@ func TestCalculateWebhookSignature_Payment(t *testing.T) {
 	keyProvider := zooz.FixedPrivateKeyProvider{"com.gojuno.gett_development": []byte("test-private-key")}
 
 	body := `{
-	"id": "150f1279-6d2c-4728-9e23-6b303f3f1f2f-2020-11-06T14:33:46.150Z-fe14a744-ade7-4a15-8df4-a0b12ac11590",
-    "created": "2020-11-06T14:33:46.150Z",
-    "account_id": "2058ac1f-ca4b-497f-8181-341e0eea5392",
-    "app_id": "com.gojuno.gett_development",
-	"payment_id": "150f1279-6d2c-4728-9e23-6b303f3f1f2f",
-	"data": {
-		"id": "150f1279-6d2c-4728-9e23-6b303f3f1f2f",
-		"amount": 100,
-		"currency": "RUB"
-	}
-}`
+		"id": "150f1279-6d2c-4728-9e23-6b303f3f1f2f-2020-11-06T14:33:46.150Z-fe14a744-ade7-4a15-8df4-a0b12ac11590",
+		"created": "2020-11-06T14:33:46.150Z",
+		"account_id": "2058ac1f-ca4b-497f-8181-341e0eea5392",
+		"app_id": "com.gojuno.gett_development",
+		"payment_id": "150f1279-6d2c-4728-9e23-6b303f3f1f2f",
+		"data": {
+			"id": "150f1279-6d2c-4728-9e23-6b303f3f1f2f",
+			"amount": 100,
+			"currency": "RUB"
+		}
+	}`
 	h := http.Header{}
 	h.Set("event-type", "payment.payment.create")
 
@@ -675,21 +667,21 @@ func TestCalculateWebhookSignature_Void(t *testing.T) {
 	keyProvider := zooz.FixedPrivateKeyProvider{"com.gojuno.gett_development": []byte("test-private-key")}
 
 	body := `{
-	"id": "83bc25f0-1710-4ea7-b610-8028f4de6d63-2020-11-06T21:09:22.356Z-fe14a744-ade7-4a15-8df4-a0b12ac11590",
-    "created": "2020-11-06T21:09:22.356Z",
-    "account_id": "2058ac1f-ca4b-497f-8181-341e0eea5392",
-    "app_id": "com.gojuno.gett_development",
-	"payment_id": "83bc25f0-1710-4ea7-b610-8028f4de6d63",
-	"data": {
-		"id": "c5f5ade4-674f-481e-a119-5827a095d352",
-		"result": {
-			"status": "Succeed"
-		},
-  		"provider_data": {
-    		"response_code": "0"
-  		}
-	}
-}`
+		"id": "83bc25f0-1710-4ea7-b610-8028f4de6d63-2020-11-06T21:09:22.356Z-fe14a744-ade7-4a15-8df4-a0b12ac11590",
+		"created": "2020-11-06T21:09:22.356Z",
+		"account_id": "2058ac1f-ca4b-497f-8181-341e0eea5392",
+		"app_id": "com.gojuno.gett_development",
+		"payment_id": "83bc25f0-1710-4ea7-b610-8028f4de6d63",
+		"data": {
+			"id": "c5f5ade4-674f-481e-a119-5827a095d352",
+			"result": {
+				"status": "Succeed"
+			},
+			"provider_data": {
+				"response_code": "0"
+			}
+		}
+	}`
 	h := http.Header{}
 	h.Set("event-type", "payment.void.create")
 


### PR DESCRIPTION
Add support for PaymentsOS webhooks.

`DecodeWebhookRequest()` decodes incoming webhook request into callback entity.

`CalculateWebhookSignature()` calculates webhook request signature. Can be useful for custom request decoding.